### PR TITLE
Feature: Deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,17 @@
 
 VERSION ?= v1d
 
-ARGS ?= --define=covidmap_version=$(VERSION)
+ARGS ?=
 CI ?= no
 APP ?= //:app
+ACTION ?= replace
+IMAGE_TARGET ?= //src:CovidMapServer-image
 TARGETS ?= $(APP)
 VERBOSE ?= no
 QUIET ?= yes
 CACHE ?= no
 STRICT ?= no
-BASE_ARGS ?=
+BASE_ARGS ?= --define=covidmap_release_tag=$(VERSION)
 BAZELISK_ARGS ?=
 CACHE_KEY ?= CovidMap
 RELEASE ?= no
@@ -90,14 +92,18 @@ build:  ## Build the app.
 dev:  ## Build the app, start it up, and auto-reload with changes.
 	$(_RULE)$(IBAZEL) run $(ARGS) $(APP)
 
+gateway:  ## Build and push the gateway (Envoy) container image.
+	$(_RULE)docker build -t us.gcr.io/covid-impact-map/gateway:$(VERSION) src/config/gateway && \
+		docker push us.gcr.io/covid-impact-map/gateway:$(VERSION)
+
 image:  ## Build a container image for the app, locally.
-	@echo "Image build not yet supported."
+	$(_RULE)$(BAZELISK) $(BAZELISK_ARGS) run $(BASE_ARGS) $(ARGS) -- $(IMAGE_TARGET)
 
 push:  ## Build and publish a container image for the app, tagged with the current source tree hash.
-	@echo "Image push not yet supported."
+	$(_RULE)$(BAZELISK) $(BAZELISK_ARGS) run $(BASE_ARGS) $(ARGS) -- $(IMAGE_TARGET)-push
 
 deploy:  ## Deploy the app to production.
-	@echo "Production deploy not yet supported."
+	$(_RULE)$(BAZELISK) $(BAZELISK_ARGS) run $(BASE_ARGS) $(ARGS) -- //src/config:app.$(ACTION)
 
 test:  ## Run any testsuites.
 	@echo "No tests yet."

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ deploy                         Deploy the app to production.
 dev                            Build the app, start it up, and auto-reload with changes.
 distclean                      Clean ephemeral targets and dependencies.
 forceclean                     DANGEROUS: Wipe all local changes and force-reset codebase.
+gateway                        Build and push the gateway (Envoy) container image.
 help                           Show this help text.
 image                          Build a container image for the app, locally.
 push                           Build and publish a container image for the app, tagged with the current source tree hash.

--- a/src/config/50-envoy.k8s.local.yaml
+++ b/src/config/50-envoy.k8s.local.yaml
@@ -86,7 +86,7 @@ spec:
       containers:
         ## Container: Gateway Proxy (Envoy)
         - name: envoy
-          image: us.gcr.io/covid-impact-map/gateway:v7c
+          image: us.gcr.io/covid-impact-map/gateway:v1d
           imagePullPolicy: Never
           ports:
             - name: tls-gateway

--- a/src/config/50-envoy.k8s.yaml
+++ b/src/config/50-envoy.k8s.yaml
@@ -86,7 +86,7 @@ spec:
       containers:
         ## Container: Gateway Proxy (Envoy)
         - name: envoy
-          image: us.gcr.io/covid-impact-map/gateway:v7c
+          image: us.gcr.io/covid-impact-map/gateway:v1d
           ports:
             - name: tls-gateway
               containerPort: 8443

--- a/src/config/BUILD.bazel
+++ b/src/config/BUILD.bazel
@@ -69,7 +69,7 @@ _k9(
     name = "covidmap",
     template = ":99-covidmap.k8s.yaml",
     images = {
-      "us.gcr.io/covid-impact-map/jvm": "//src:COVIDMapServer-image",
+      "us.gcr.io/covid-impact-map/jvm": "//src:CovidMapServer-image",
     },
 )
 
@@ -96,6 +96,15 @@ k8s_config(
         ":envoy",
         ":services",
         ":redis",
+        ":covidmap",
+    ]
+)
+
+k8s_config(
+    name = "app",
+    deps = [
+        ":envoy",
+        ":services",
         ":covidmap",
     ]
 )

--- a/src/config/gateway/Dockerfile
+++ b/src/config/gateway/Dockerfile
@@ -1,8 +1,8 @@
 
 FROM envoyproxy/envoy-alpine:v1.13.0
 COPY envoy.yaml /etc/envoy/envoy.yaml
-COPY origin.key /etc/ssl/tls.key
-COPY origin.crt /etc/ssl/tls.crt
+COPY sandbox.key /etc/ssl/tls.key
+COPY sandbox.crt /etc/ssl/tls.crt
 EXPOSE 8443
 EXPOSE 8090
 EXPOSE 9901


### PR DESCRIPTION
This changeset adds `make image`, `make push`, and `make deploy` commands, which enable (1) building container images, (2) pushing them to GCR, and (3) deploying them to K8S.

- [x] Ability to make container images
- [x] Ability to push container images
- [x] Ability to deploy